### PR TITLE
Remove bootstrap directory from list of Laravel folders

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -116,7 +116,7 @@ class Config extends \PhpCsFixer\Config
     public static function forLaravel($folders = [], $target = null)
     {
         $folders = (array) $folders;
-        $folders = array_merge(['app', 'bootstrap', 'config', 'database', 'routes', 'tests'], $folders);
+        $folders = array_merge(['app', 'config', 'database', 'routes', 'tests'], $folders);
 
         return static::fromFolders($folders, $target);
     }


### PR DESCRIPTION
### Removed
- bootstrap directory from list of laravel directories to fix.

It's failing on circleCI because it's including the `bootstrap/cache` file which doesn't really matter. 