### PR TITLE
Allow excluding subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ require 'vendor/autoload.php';
 return Madewithlove\PhpCsFixer\Config::fromFolders(['src']);
 ```
 
+To exclude a subfolder:
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+return Madewithlove\PhpCsFixer\Config::fromFolders(['src'], null, ['ignoreThisDir']);
+```
+This will skip `src/ignoreThisDir` or `src/foo/bar/ignoreThisDir`. (_The folder has to be relative to the ones in the first argument._)
+
 You can also override rules per-project without overriding the core rules like this:
 
 **.php_cs**

--- a/src/Config.php
+++ b/src/Config.php
@@ -155,15 +155,16 @@ class Config extends \PhpCsFixer\Config
     /**
      * @param string|string[] $folders
      * @param string|null     $target
+     * @param string|string[] $exclude folder to exclude
      *
      * @return $this
      */
-    public static function fromFolders($folders, $target = null)
+    public static function fromFolders($folders, $target = null, $exclude = [])
     {
         $config = new static($target);
 
         return $config->setFinder(
-            Finder::create()->in($folders)
+            Finder::create()->in($folders)->exclude($exclude)
         );
     }
 


### PR DESCRIPTION
Currently it's not possible to lint on a folder but exclude a certain subfolder inside it. 

This is a simple PR to make use of the (internal dependee) Finder's feature to exclude folders.