### PR TITLE
Fix minor issues & add more rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Enforce Unix newlines
+* text=lf
+
+# Exclude unused files (see: https://redd.it/2jzp6k)
+/.editorconfig  export-ignore
+/.gitattributes export-ignore
+/.github        export-ignore
+/.gitignore     export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0']
+                php-versions: ['7.4', '8.0', '8.1']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor/
 .php_cs.cache
+.idea

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 require 'vendor/autoload.php';
 
 return Madewithlove\PhpCsFixer\Config::fromFolders(['src']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,6 +42,7 @@ class Config extends \PhpCsFixer\Config
                 'no_trailing_comma_in_singleline_array' => true,
                 'no_unused_imports' => true,
                 'no_useless_return' => true,
+                'object_operator_without_whitespace' => true,
                 'phpdoc_no_useless_inheritdoc' => true,
                 'phpdoc_var_without_name' => true,
                 'php_unit_method_casing' => false,

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Madewithlove\PhpCsFixer;
 
+use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Finder;
 
 class Config extends \PhpCsFixer\Config
@@ -53,7 +54,7 @@ class Config extends \PhpCsFixer\Config
      * @param string[] $folders
      * @param string[] $exclude folder to exclude
      */
-    public static function fromFolders(array $folders, ?string $target = null, array $exclude = []): self
+    public static function fromFolders(array $folders, ?string $target = null, array $exclude = []): ConfigInterface
     {
         $config = new static($target);
 
@@ -65,7 +66,7 @@ class Config extends \PhpCsFixer\Config
     /**
      * @param string[] $folders
      */
-    public static function forLaravel(array $folders = [], ?string $target = null): self
+    public static function forLaravel(array $folders = [], ?string $target = null): ConfigInterface
     {
         $folders = (array) $folders;
         $folders = array_merge(['app', 'config', 'database', 'routes', 'tests'], $folders);
@@ -76,7 +77,7 @@ class Config extends \PhpCsFixer\Config
     /**
      * Merge a set of rules with the core ones.
      */
-    public function mergeRules(array $rules): self
+    public function mergeRules(array $rules): ConfigInterface
     {
         return $this->setRules(array_merge(
             $this->getRules(),
@@ -84,7 +85,7 @@ class Config extends \PhpCsFixer\Config
         ));
     }
 
-    public function enablePhpunitRules(): self
+    public function enablePhpunitRules(): ConfigInterface
     {
         return $this->mergeRules([
             'php_unit_dedicate_assert' => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -52,6 +52,7 @@ class Config extends \PhpCsFixer\Config
                 'single_quote' => true,
                 'trailing_comma_in_multiline' => ['elements' => ['arrays']],
                 'trim_array_spaces' => true,
+                'whitespace_after_comma_in_array' => true,
             ]);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -50,6 +50,7 @@ class Config extends \PhpCsFixer\Config
                 'strict_param' => true,
                 'single_quote' => true,
                 'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+                'trim_array_spaces' => true,
             ]);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -32,6 +32,7 @@ class Config extends \PhpCsFixer\Config
             ->setRules([
                 '@PSR12' => true,
                 'array_syntax' => ['syntax' => 'short'],
+                'cast_spaces' => true,
                 'concat_space' => ['spacing' => 'one'],
                 'declare_strict_types' => true,
                 'modernize_types_casting' => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -68,7 +68,6 @@ class Config extends \PhpCsFixer\Config
      */
     public static function forLaravel(array $folders = [], ?string $target = null): ConfigInterface
     {
-        $folders = (array) $folders;
         $folders = array_merge(['app', 'config', 'database', 'routes', 'tests'], $folders);
 
         return static::fromFolders($folders, $target);

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,22 +30,22 @@ class Config extends \PhpCsFixer\Config
             ->setRiskyAllowed(true)
             ->setRules([
                 '@PSR12' => true,
-                'strict_param' => true,
                 'array_syntax' => ['syntax' => 'short'],
-                'php_unit_method_casing' => false,
-                'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-                'no_trailing_comma_in_singleline_array' => true,
-                'no_unused_imports' => true,
                 'concat_space' => ['spacing' => 'one'],
+                'declare_strict_types' => true,
                 'modernize_types_casting' => true,
-                'no_superfluous_phpdoc_tags' => true,
-                'phpdoc_no_useless_inheritdoc' => true,
-                'phpdoc_var_without_name' => true,
-                'protected_to_private' => true,
-                'single_quote' => true,
                 'no_empty_comment' => true,
                 'no_empty_phpdoc' => true,
-                'declare_strict_types' => true,
+                'no_superfluous_phpdoc_tags' => true,
+                'no_trailing_comma_in_singleline_array' => true,
+                'no_unused_imports' => true,
+                'phpdoc_no_useless_inheritdoc' => true,
+                'phpdoc_var_without_name' => true,
+                'php_unit_method_casing' => false,
+                'protected_to_private' => true,
+                'strict_param' => true,
+                'single_quote' => true,
+                'trailing_comma_in_multiline' => ['elements' => ['arrays']],
             ]);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,7 @@ class Config extends \PhpCsFixer\Config
                 'no_superfluous_phpdoc_tags' => true,
                 'no_trailing_comma_in_singleline_array' => true,
                 'no_unused_imports' => true,
+                'no_useless_return' => true,
                 'phpdoc_no_useless_inheritdoc' => true,
                 'phpdoc_var_without_name' => true,
                 'php_unit_method_casing' => false,

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,6 +42,7 @@ class Config extends \PhpCsFixer\Config
                 'no_trailing_comma_in_singleline_array' => true,
                 'no_unused_imports' => true,
                 'no_useless_return' => true,
+                'no_whitespace_before_comma_in_array' => true,
                 'object_operator_without_whitespace' => true,
                 'phpdoc_no_useless_inheritdoc' => true,
                 'phpdoc_var_without_name' => true,


### PR DESCRIPTION
This PR;
- sorts rules alphabetically (to easily lookup),
- ignores `.idea` directory from VCS,
- bumps `actions/checkout` to the latest version,
- fixes return types,
- removes unnecessary type casting,
- adds `.editorconfig` and `.gitattributes` files,
- adds [`cast_spaces`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/cast_notation/cast_spaces.rst), [`no_useless_return`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/return_notation/no_useless_return.rst), [`object_operator_without_whitespace`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/operator/object_operator_without_whitespace.rst), [`trim_array_spaces`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/array_notation/trim_array_spaces.rst), [`no_whitespace_before_comma_in_array`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst), [`whitespace_after_comma_in_array`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/array_notation/whitespace_after_comma_in_array.rst) rules.