### PR TITLE
Bump `friendsofphp/php-cs-fixer` and include latest PHP versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0', '8.1', '8.2']
+                php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
                 include:
-                    - php-versions: 8.2
+                    - php-versions: 8.4
                       PHP_CS_FIXER_IGNORE_ENV: 1
         name: PHP ${{ matrix.php-versions }}
         steps:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.4 | ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.13"
+        "friendsofphp/php-cs-fixer": "^3.75"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Changed
- Bumped `friendsofphp/php-cs-fixer` from version `^3.13` to `^3.75`.
- Bumped `actions/checkout` from version `v3` to `v4`.
- Included the PHP versions 8.3 and 8.4 in the matrix of tested PHP versions.